### PR TITLE
Test AD without delay length estimation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,10 +26,10 @@ UnPack = "0.1, 1.0"
 julia = "1"
 
 [extras]
-Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 DiffEqProblemLibrary = "a077e3f3-b75c-5d7f-a0c6-6bc4c8ec64a9"
+FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -37,4 +37,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Calculus", "DiffEqCallbacks", "DiffEqDevTools", "DiffEqProblemLibrary", "ForwardDiff", "Random", "SafeTestsets", "Test", "Unitful"]
+test = ["DiffEqCallbacks", "DiffEqDevTools", "DiffEqProblemLibrary", "FiniteDiff", "ForwardDiff", "Random", "SafeTestsets", "Test", "Unitful"]

--- a/test/interface/ad.jl
+++ b/test/interface/ad.jl
@@ -1,9 +1,13 @@
-using DelayDiffEq, Calculus, ForwardDiff
+using DelayDiffEq
+
+import FiniteDiff
+import ForwardDiff
+
 using LinearAlgebra, Test
 
 # Hutchinson's equation
 function f(du, u, h, p, t)
-  du[1] = p[1] * u[1] * (1 - h(p, t - p[2])[1] / p[3])
+  du[1] = p[2] * u[1] * (1 - h(p, t - p[1])[1] / p[3])
   nothing
 end
 
@@ -18,11 +22,19 @@ h(p, t) = [p[4]]
     dot(diff, diff)
   end
 
+  # with delay length estimation
   p = [1.0, 1.0, 1.0, 0.0, 1.0]
-  findiff = Calculus.finite_difference(test, p)
+  findiff = FiniteDiff.finite_difference_gradient(test, p)
   fordiff = @test_logs (:warn, r"^dt <= dtmin") ForwardDiff.gradient(test, p)
-
   @test_broken findiff ≈ fordiff
+
+  # without delay length estimation
+  p = [1.0, 1.0, 0.0, 1.0]
+  findiff2 = FiniteDiff.finite_difference_gradient(p -> test(vcat(1, p)), p)
+  fordiff2 = @test_logs (:warn, r"^dt <= dtmin") ForwardDiff.gradient(p -> test(vcat(1, p)), p)
+  @test_broken findiff2 ≈ fordiff2
+
+  @test findiff[2:end] ≈ findiff2
 end
 
 @testset "Jacobian" begin
@@ -32,11 +44,19 @@ end
     solve(prob, MethodOfSteps(Tsit5()); abstol = 1e-14, reltol = 1e-14).u[end]
   end
 
+  # with delay length estimation
   p = [1.0, 1.0, 1.0, 0.0, 1.0]
-  findiff = Calculus.finite_difference_jacobian(test, p)
+  findiff = FiniteDiff.finite_difference_jacobian(test, p)
   fordiff = @test_logs (:warn, r"^dt <= dtmin") ForwardDiff.jacobian(test, p)
-
   @test_broken findiff ≈ fordiff
+
+  # without delay length estimation
+  p = [1.0, 1.0, 0.0, 1.0]
+  findiff2 = FiniteDiff.finite_difference_jacobian(p -> test(vcat(1, p)), p)
+  fordiff2 = @test_logs (:warn, r"^dt <= dtmin") ForwardDiff.jacobian(p -> test(vcat(1, p)), p)
+  @test_broken findiff2 ≈ fordiff2
+
+  @test findiff[:, 2:end] ≈ findiff2
 end
 
 @testset "Hessian" begin
@@ -48,9 +68,17 @@ end
     dot(diff, diff)
   end
 
+  # with delay length estimation
   p = [1.0, 1.0, 1.0, 0.0, 1.0]
-  findiff = Calculus.finite_difference_hessian(test, p)
+  findiff = FiniteDiff.finite_difference_hessian(test, p)
   fordiff = @test_logs (:warn, r"^dt <= dtmin") ForwardDiff.hessian(test, p)
-
   @test_broken findiff ≈ fordiff
+
+  # without delay length estimation
+  p = [1.0, 1.0, 0.0, 1.0]
+  findiff2 = FiniteDiff.finite_difference_hessian(p -> test(vcat(1, p)), p)
+  fordiff2 = @test_logs (:warn, r"^dt <= dtmin") ForwardDiff.hessian(p -> test(vcat(1, p)), p)
+  @test_broken findiff2 ≈ fordiff2
+
+  @test findiff[2:end, 2:end] ≈ findiff2
 end

--- a/test/interface/ad.jl
+++ b/test/interface/ad.jl
@@ -34,7 +34,9 @@ h(p, t) = [p[4]]
   fordiff2 = @test_logs (:warn, r"^dt <= dtmin") ForwardDiff.gradient(p -> test(vcat(1, p)), p)
   @test_broken findiff2 ≈ fordiff2
 
+  # consistency checks
   @test findiff[2:end] ≈ findiff2
+  @test fordiff[2:end] ≈ fordiff2
 end
 
 @testset "Jacobian" begin
@@ -56,7 +58,9 @@ end
   fordiff2 = @test_logs (:warn, r"^dt <= dtmin") ForwardDiff.jacobian(p -> test(vcat(1, p)), p)
   @test_broken findiff2 ≈ fordiff2
 
+  # consistency checks
   @test findiff[:, 2:end] ≈ findiff2
+  @test fordiff[:, 2:end] ≈ fordiff2
 end
 
 @testset "Hessian" begin
@@ -80,5 +84,7 @@ end
   fordiff2 = @test_logs (:warn, r"^dt <= dtmin") ForwardDiff.hessian(p -> test(vcat(1, p)), p)
   @test_broken findiff2 ≈ fordiff2
 
+  # consistency checks
   @test findiff[2:end, 2:end] ≈ findiff2
+  @test fordiff[2:end, 2:end] ≈ fordiff2
 end


### PR DESCRIPTION
It seems AD with ForwardDiff is broken even without delay length estimation.