### PR TITLE
Switch to DataStructures 0.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-DataStructures = "0.17"
+DataStructures = "0.18"
 DiffEqBase = "6"
 OrdinaryDiffEq = "5.28"
 RecursiveArrayTools = "2"

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -511,7 +511,7 @@ end
 function DiffEqBase.step!(integrator::DDEIntegrator)
   @inbounds begin
     if integrator.opts.advance_to_tstop
-      while integrator.tdir * integrator.t < top(integrator.opts.tstops)
+      while integrator.tdir * integrator.t < first(integrator.opts.tstops)
         OrdinaryDiffEq.loopheader!(integrator)
         DiffEqBase.check_error!(integrator) === :Success || return
         OrdinaryDiffEq.perform_step!(integrator)

--- a/src/integrators/utils.jl
+++ b/src/integrators/utils.jl
@@ -161,7 +161,7 @@ function OrdinaryDiffEq.handle_discontinuities!(integrator::DDEIntegrator)
     d = pop!(integrator.opts.d_discontinuities)
     order = d.order
     while !isempty(integrator.opts.d_discontinuities) &&
-        top(integrator.opts.d_discontinuities) == integrator.tdir * integrator.t
+        first(integrator.opts.d_discontinuities) == integrator.tdir * integrator.t
 
         d2 = pop!(integrator.opts.d_discontinuities)
         order = min(order, d2.order)
@@ -174,7 +174,7 @@ function OrdinaryDiffEq.handle_discontinuities!(integrator::DDEIntegrator)
         maxΔt = 10eps(integrator.t)
 
         while !isempty(integrator.opts.d_discontinuities) &&
-            abs(top(integrator.opts.d_discontinuities).t - integrator.tdir * integrator.t) < maxΔt
+            abs(first(integrator.opts.d_discontinuities).t - integrator.tdir * integrator.t) < maxΔt
 
             d2 = pop!(integrator.opts.d_discontinuities)
             order = min(order, d2.order)
@@ -182,7 +182,7 @@ function OrdinaryDiffEq.handle_discontinuities!(integrator::DDEIntegrator)
 
         # also remove all corresponding time stops
         while !isempty(integrator.opts.tstops) &&
-            abs(top(integrator.opts.tstops) - integrator.tdir * integrator.t) < maxΔt
+            abs(first(integrator.opts.tstops) - integrator.tdir * integrator.t) < maxΔt
 
             pop!(integrator.opts.tstops)
         end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -310,7 +310,7 @@ function DiffEqBase.solve!(integrator::DDEIntegrator)
 
   # step over all stopping time points, similar to solving with ODE integrators
   @inbounds while !isempty(tstops)
-    while tdir * integrator.t < top(tstops)
+    while tdir * integrator.t < first(tstops)
       # apply step or adapt step size
       OrdinaryDiffEq.loopheader!(integrator)
 


### PR DESCRIPTION
Tests will fail since OrdinaryDiffEq is not compatible with DataStructures 0.18 yet.