### PR TITLE
Sync DelayDiffEq with changes in OrdinaryDiffEq

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.25.1"
+version = "5.25.2"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"


### PR DESCRIPTION
This PR syncs DelayDiffEq with the changes in `src/solve.jl` in OrdinaryDiffEq which started to diverge from the implementation in DelayDiffEq.