### PR TITLE
Fix type inference

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.28.0"
+version = "5.28.1"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/track.jl
+++ b/src/track.jl
@@ -133,7 +133,7 @@ function discontinuity_time(integrator::DDEIntegrator, lag, T, (bottom_Θ, top_�
     end
 
     Θ = NonlinearSolve.solve(
-      NonlinearSolve.NonlinearProblem(zero_func, (bottom_Θ, top_Θ)),
+      NonlinearSolve.NonlinearProblem{false}(zero_func, (bottom_Θ, top_Θ)),
       NonlinearSolve.Falsi(),
     ).left
   end

--- a/test/interface/saveat.jl
+++ b/test/interface/saveat.jl
@@ -92,13 +92,7 @@ end
     @test sol2.u == dde_int2.sol.u
 
     # time points of solution
-    if saveat isa Number
-      @test symdiff(sol.t, sol2.t) == (save_start ? [100.0, 25.0, 50.0, 75.0] :
-                                       [0.0, 100.0, 25.0, 50.0, 75.0])
-    else
-      @test symdiff(sol.t, sol2.t) == (save_start ? [25.0, 50.0, 75.0] :
-                                       [0.0, 25.0, 50.0, 75.0])
-    end
+    @test symdiff(sol.t, sol2.t) == (save_start ? [25.0, 50.0, 75.0] : [0.0, 25.0, 50.0, 75.0])
 
     # history is equal to solution above
     @test sol.t == dde_int2.integrator.sol.t
@@ -122,13 +116,7 @@ end
     @test sol2.u == dde_int2.sol.u
 
     # time points of solution
-    if saveat isa Number
-      @test symdiff(sol.t, sol2.t) == (save_end ? [100.0, 25.0, 50.0, 75.0] :
-                                       [100.0, 25.0, 50.0, 75.0])
-    else
-      @test symdiff(sol.t, sol2.t) == (save_end ? [25.0, 50.0, 75.0] :
-                                       [25.0, 50.0, 75.0])
-    end
+    @test symdiff(sol.t, sol2.t) == [25.0, 50.0, 75.0]
 
     # history is equal to solution above
     @test sol.t == dde_int2.integrator.sol.t

--- a/test/regression/inference.jl
+++ b/test/regression/inference.jl
@@ -23,3 +23,13 @@ DDEProblemLibrary.importddeproblems()
         @test_broken @inferred init(prob_scalar, ddealg)
     end
 end
+
+@testset "discontinuity_time" begin
+    prob_inplace = DDEProblemLibrary.prob_dde_constant_1delay_ip
+    prob_scalar = DDEProblemLibrary.prob_dde_constant_1delay_scalar
+
+    for prob in (prob_inplace, prob_scalar)
+        int = init(prob, MethodOfSteps(Tsit5()))
+        @inferred DelayDiffEq.discontinuity_time(int, (u, p, t) -> 1.0, 0.0, (0.5, 1.5))
+    end
+end


### PR DESCRIPTION
I noticed this type instability when switching Bijectors to NonlinearSolve. I imagine that it also exists in DiffEqBase since the type parameter is not specified there either.