### PR TITLE
More general history function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.28.1"
+version = "5.28.2"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/history_function.jl
+++ b/src/history_function.jl
@@ -87,6 +87,6 @@ function (f::HistoryFunction)(val, p, t, ::Type{Val{deriv}}=Val{0}; idxs=nothing
     # handle extrapolations at initial time point
     return constant_extrapolant!(val, t, integrator, idxs, Val{deriv})
   else
-    return integrator!(val, t, Val{deriv}; idxs=idxs)
+    return integrator(val, t, Val{deriv}; idxs=idxs)
   end
 end

--- a/src/history_function.jl
+++ b/src/history_function.jl
@@ -50,7 +50,7 @@ function (f::HistoryFunction)(p, t, ::Type{Val{deriv}}=Val{0}; idxs=nothing) whe
     # handle extrapolations at initial time point
     return constant_extrapolant(t, integrator, idxs, Val{deriv})
   else
-    return OrdinaryDiffEq.current_interpolant(t, integrator, idxs, Val{deriv})
+    return integrator(t, Val{deriv}; idxs=idxs)
   end
 end
 
@@ -87,6 +87,6 @@ function (f::HistoryFunction)(val, p, t, ::Type{Val{deriv}}=Val{0}; idxs=nothing
     # handle extrapolations at initial time point
     return constant_extrapolant!(val, t, integrator, idxs, Val{deriv})
   else
-    return OrdinaryDiffEq.current_interpolant!(val, t, integrator, idxs, Val{deriv})
+    return integrator!(val, t, Val{deriv}; idxs=idxs)
   end
 end

--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -14,6 +14,16 @@ mutable struct HistoryODEIntegrator{algType,IIP,uType,tType,tdirType,ksEltype,So
   cache::CacheType
 end
 
+function (integrator::HistoryODEIntegrator)(t, deriv::Type=Val{0}; idxs=nothing)
+    OrdinaryDiffEq.current_interpolant(t, integrator, idxs, deriv)
+end
+
+function (integrator::HistoryODEIntegrator)(
+    val::AbstractArray, t::Union{Number,AbstractArray}, deriv::Type=Val{0}; idxs=nothing
+)
+    OrdinaryDiffEq.current_interpolant!(val, t, integrator, idxs, deriv)
+end
+
 mutable struct DDEIntegrator{algType,IIP,uType,tType,P,eigenType,tTypeNoUnits,tdirType,
                              ksEltype,SolType,F,CacheType,IType,FP,O,dAbsType,dRelType,H,
                              tstopsType,discType,FSALType,EventErrorType,CallbackCacheType} <: AbstractDDEIntegrator{algType,IIP,uType,tType}


### PR DESCRIPTION
Removes some OrdinaryDiffEq-specific code in the implementation of `HistoryFunction`. This allows to remvove `StochasticDelayDiffEq.HistoryFunction`.