### PR TITLE
Wrap all AbstractDDEFunction which have the expected fields

### DIFF
--- a/src/functionwrapper.jl
+++ b/src/functionwrapper.jl
@@ -40,7 +40,7 @@ struct ODEFunctionWrapper{iip,F,H,TMM,Ta,Tt,TJ,JP,SP,TW,TWt,TPJ,S,TCV} <: DiffEq
   colorvec::TCV
 end
 
-function ODEFunctionWrapper(f::DDEFunction, h)
+function ODEFunctionWrapper(f::DiffEqBase.AbstractDDEFunction, h)
   # wrap functions
   jac = @wrap_h jac(J, u, h, p, t)
   Wfact = @wrap_h Wfact(W, u, h, p, dtgamma, t)


### PR DESCRIPTION
Since now there are more subtypes of `AbstractDDEFunction` than just `DDEFunction`, `ODEFunctionWrapper` is changed to accept any `AbstractDDEFunction` `f` that fits the interface:
- `isinplace(f)` returns `Bool`
- `f.f` is defined as the one function that contains the entire DDE.
- `f.mass_matrix` is defined
- `f.analytic` is defined
- `f.jac` is defined
- `f.jac_prototype` is defined
- `f.sparsity` is defined
- `f.Wfact` is defined
- `f.Wfact_t` is defined
- `f.paramjac` is defined
- `f.syms` is defined
- `f.colorvec` is defined

(i.e. any `AbstractDDEFunction` that "looks like" a regular `DDEFunction`)

Companion PR of https://github.com/SciML/SciMLBase.jl/pull/14.