### PR TITLE
Fix reset of `saveiter_dense` in `reinit!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.29.2"
+version = "5.29.3"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -294,6 +294,7 @@ function DiffEqBase.reinit!(integrator::HistoryODEIntegrator, u0 = integrator.so
 
     # reset iteration counter
     integrator.saveiter = 1
+    integrator.saveiter_dense = 1
   end
 
   nothing
@@ -387,6 +388,9 @@ function DiffEqBase.reinit!(integrator::DDEIntegrator, u0 = integrator.sol.prob.
 
     # reset iteration counter
     integrator.saveiter = resize_start
+    if integrator.opts.dense
+      integrator.saveiter_dense = resize_start
+    end
 
     # erase array of tracked discontinuities
     if order_discontinuity_t0 ≤ OrdinaryDiffEq.alg_maximum_order(integrator.alg)

--- a/test/integrators/reinit.jl
+++ b/test/integrators/reinit.jl
@@ -40,4 +40,24 @@ const alg = MethodOfSteps(BS3(); constrained = false)
     @test u == sol.u
     @test t == sol.t
   end
+
+  # https://github.com/SciML/OrdinaryDiffEq.jl/issues/1394
+  @testset "saveiter_dense" begin
+    integrator = init(prob, alg)
+    solve!(integrator)
+
+    # ensure that the counters were updated
+    for i in (integrator, integrator.integrator)
+        @test i.saveiter > 1
+        @test i.saveiter_dense > 1
+    end
+
+    reinit!(integrator)
+
+    # check that the counters are reset
+    for i in (integrator, integrator.integrator)
+        @test i.saveiter == 1
+        @test i.saveiter_dense == 1
+    end
+  end
 end


### PR DESCRIPTION
Fixes the issue described in https://github.com/SciML/OrdinaryDiffEq.jl/issues/1394 for DDEs.