### PR TITLE
Fix paper build for JCON

### DIFF
--- a/paper/paper.tex
+++ b/paper/paper.tex
@@ -15,7 +15,7 @@
 
 % configuration
 \pgfplotsset{
-    compat=1.18,
+    compat=1.16,
     % CSV files use comma as delimiter
     table/col sep=comma,
     % folders with CSV files


### PR DESCRIPTION
I managed to get Whedon installed locally so I could run this, and this was the magic change that got things to work.

Here's the paper it built:

[10.21105.joss.00109.pdf](https://github.com/SciML/DelayDiffEq.jl/files/10661085/10.21105.joss.00109.pdf)

x-ref: https://github.com/JuliaCon/proceedings-review/issues/109