### PR TITLE
update retcode from symbol

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.47.1"
+version = "5.47.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -256,7 +256,7 @@ function DiffEqBase.last_step_failed(integrator::DDEIntegrator)
 end
 
 # terminate integration
-function DiffEqBase.terminate!(integrator::DDEIntegrator, retcode = :Terminated)
+function DiffEqBase.terminate!(integrator::DDEIntegrator, retcode = ReturnCode.Terminated)
     integrator.sol = DiffEqBase.solution_new_retcode(integrator.sol, retcode)
     integrator.opts.tstops.valtree = typeof(integrator.opts.tstops.valtree)()
     nothing

--- a/test/integrators/events.jl
+++ b/test/integrators/events.jl
@@ -34,6 +34,7 @@ end
 
 # discrete callback
 @testset "discrete" begin
+    # Automatic absolute tolerances
     cb = AutoAbstol()
 
     sol1 = solve(prob, alg, callback = cb)
@@ -42,6 +43,11 @@ end
 
     @test sol3.errors[:L2] < 1.4e-3
     @test sol3.errors[:L∞] < 4.1e-3
+
+    # Terminate early
+    cb = DiscreteCallback((u, t, integrator) -> t == 4, terminate!)
+    sol = @test_logs solve(prob, alg; callback = cb, tstops = [4.0])
+    @test sol.t[end] == 4
 end
 
 @testset "save discontinuity" begin


### PR DESCRIPTION
fix terminate! to update solution's retcode with a SciMLBase.ReturnCode instead of a Symbol (raises warning)

## Checklist

- [X] Appropriate tests were added
- [X] Any code changes were done in a way that does not break public API
- [X] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [X] Any new documentation only uses public API
  
## Additional context

Followed what's in [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/src/integrators/integrator_interface.jl#L348C10-L348C20)