### PR TITLE
Handle empty solution in `HistoryFunction` correctly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "5.47.2"
+version = "5.47.3"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/history_function.jl
+++ b/src/history_function.jl
@@ -4,7 +4,7 @@
 Wrap history function `h` and integrator `integrator` to create a common
 interface for retrieving values at any time point with varying accuracy.
 
-Before the initial time point of the solution of the `integrator` values are calculated by
+Before the initial time point of the `integrator` values are calculated by
 history function `h`, for time points up to the final time point of the solution
 interpolated values of the solution are returned, and after the final time point an inter-
 or extrapolation of the current state of the `integrator` is retrieved.
@@ -24,7 +24,7 @@ function (f::HistoryFunction)(p, t, ::Type{Val{deriv}} = Val{0};
 
     tdir_t = tdir * t
 
-    @inbounds if tdir_t < tdir * sol.t[1]
+    if tdir_t < tdir * sol.prob.tspan[1]
         if deriv == 0 && idxs === nothing
             return f.h(p, t)
         elseif idxs === nothing
@@ -36,14 +36,18 @@ function (f::HistoryFunction)(p, t, ::Type{Val{deriv}} = Val{0};
         end
     end
 
-    tdir_solt = tdir * sol.t[end]
-    if tdir_t <= tdir_solt
-        return sol.interp(t, idxs, Val{deriv}, p)
-    end
+    if !isempty(sol.t)
+        tdir_solt = tdir * sol.t[end]
+        if tdir_t <= tdir_solt
+            return sol.interp(t, idxs, Val{deriv}, p)
+        end
 
-    # history function is evaluated at time point past the final time point of
-    # the current solution
-    if tdir_t - tdir_solt > 10 * eps(tdir_t)
+        # history function is evaluated at time point past the final time point of
+        # the current solution
+        if tdir_t - tdir_solt > 10 * eps(tdir_t)
+            f.isout = true
+        end
+    else
         f.isout = true
     end
 
@@ -62,7 +66,7 @@ function (f::HistoryFunction)(val, p, t, ::Type{Val{deriv}} = Val{0};
 
     tdir_t = tdir * t
 
-    @inbounds if tdir_t < tdir * sol.t[1]
+    if tdir_t < tdir * sol.prob.tspan[1]
         if deriv == 0 && idxs === nothing
             return f.h(val, p, t)
         elseif idxs === nothing
@@ -74,14 +78,18 @@ function (f::HistoryFunction)(val, p, t, ::Type{Val{deriv}} = Val{0};
         end
     end
 
-    tdir_solt = tdir * sol.t[end]
-    if tdir_t <= tdir_solt
-        return sol.interp(val, t, idxs, Val{deriv}, p)
-    end
+    if !isempty(sol.t)
+        tdir_solt = tdir * sol.t[end]
+        if tdir_t <= tdir_solt
+            return sol.interp(val, t, idxs, Val{deriv}, p)
+        end
 
-    # history function is evaluated at time point past the final time point of
-    # the current solution
-    if tdir_t - tdir_solt > 10 * eps(tdir_t)
+        # history function is evaluated at time point past the final time point of
+        # the current solution
+        if tdir_t - tdir_solt > 10 * eps(tdir_t)
+            f.isout = true
+        end
+    else
         f.isout = true
     end
 


### PR DESCRIPTION
I ran into a weird issue in some private downstream code which ultimately I think points to a problem in the downstream code. However, even though I wasn't able to reproduce the problem with DelayDiffEq alone, I think we should fix the definition of the `HistoryFunction`: Currently, it performs unsafe indexing that is even annotated with `@inbounds` 😕 