### PR TITLE
Fix waltman regression test

### DIFF
--- a/test/regression/waltman.jl
+++ b/test/regression/waltman.jl
@@ -2,7 +2,7 @@ using DelayDiffEq, DDEProblemLibrary
 using LinearAlgebra, Test, LinearSolve
 
 const PROB_WALTMAN = DDEProblemLibrary.prob_dde_RADAR5_waltman_5
-const PROB_KWARGS = (reltol = 1e-6, abstol = [1e-21, 1e-21, 1e-21, 1e-21, 1e-9, 1e-9])
+const PROB_KWARGS = (reltol = 1e-7, abstol = [1e-21, 1e-21, 1e-21, 1e-21, 1e-9, 1e-9])
 
 # solution at final time point T = 300 obtained from RADAR5
 # with relative tolerance 1e-6 and componentwise absolute tolerances


### PR DESCRIPTION
My current understanding is we hit a 1 in a gazillion chance case where the factorizations are both fine but the numerical error causes one to give a solution that goes just below zero and errors purely due to how the numerical errors align. I cannot find anything actually different between the solves other than the factorization, and as shown in the text file there, the factorizations give the same value at essentially every step to about 16 digits of accuracy. The abstol on this is 21 digits of accuracy because there are some values that shouldn't go below zero, and so it seems that this random difference in the LU actually makes a difference here, and so it's not a real broken test but really just a random fluctuation.
