### PR TITLE
Fix issue with callbacks

### DIFF
--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -498,9 +498,10 @@ function DiffEqBase.addsteps!(integrator::DDEIntegrator, args...)
 end
 
 function DiffEqBase.change_t_via_interpolation!(integrator::DDEIntegrator,
-        t, modify_save_endpoint::Type{Val{T}} = Val{false}) where T
+        t, modify_save_endpoint::Type{Val{T}} = Val{false}, reinitialize_alg = nothing) where T
     OrdinaryDiffEqCore._change_t_via_interpolation!(integrator, t, modify_save_endpoint)
 end
+
 
 # update integrator when u is modified by callbacks
 function OrdinaryDiffEqCore.handle_callback_modifiers!(integrator::DDEIntegrator)

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -499,7 +499,7 @@ end
 
 function DiffEqBase.change_t_via_interpolation!(integrator::DDEIntegrator,
         t, modify_save_endpoint::Type{Val{T}} = Val{false}, reinitialize_alg = nothing) where T
-    OrdinaryDiffEqCore._change_t_via_interpolation!(integrator, t, modify_save_endpoint)
+    OrdinaryDiffEqCore._change_t_via_interpolation!(integrator, t, modify_save_endpoint, reinitialize_alg)
 end
 
 


### PR DESCRIPTION
## Checklist

- [ x] Appropriate tests were added
- [ x] Any code changes were done in a way that does not break public API
- [ x] All documentation related to code changes were updated
- [ x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ x] Any new documentation only uses public API
  
## Additional context
This is what was causing some of the integrator tests to fail, `change_t_via_interpolation!` wasn't getting the correct number of arguments, causing callbacks to fail. This should fix using callbacks with DelayDiffEq.
