### PR TITLE
Fix cache and initialization tests

### DIFF
--- a/test/integrators/cache.jl
+++ b/test/integrators/cache.jl
@@ -48,7 +48,7 @@ println("Rosenbrock23")
 end
 
 println("Rodas4")
-@test_nowarn solve(prob, MethodOfSteps(Rodas4(chunk_size = 1)); dt = 0.5)
+@test_nowarn solve(prob, MethodOfSteps(Rodas4()); dt = 0.5)
 
 println("Rodas5")
-@test_nowarn solve(prob, MethodOfSteps(Rodas5(chunk_size = 1)); dt = 0.5)
+@test_nowarn solve(prob, MethodOfSteps(Rodas5()); dt = 0.5)

--- a/test/integrators/cache.jl
+++ b/test/integrators/cache.jl
@@ -41,7 +41,7 @@ end
 println("Check some other integrators")
 
 println("Rosenbrock23")
-@test_nowarn solve(prob, MethodOfSteps(Rosenbrock23(chunk_size = 1)); dt = 0.5)
+@test_nowarn solve(prob, MethodOfSteps(Rosenbrock23()); dt = 0.5)
 
 @testset "$(nameof(typeof(alg)))" for alg in CACHE_TEST_ALGS
     @test_nowarn solve(prob, MethodOfSteps(alg); dt = 0.5)

--- a/test/integrators/initialization.jl
+++ b/test/integrators/initialization.jl
@@ -1,6 +1,5 @@
 using DelayDiffEq
 using SciMLBase
-using SciMLBase
 using LinearAlgebra
 using Test
 

--- a/test/integrators/initialization.jl
+++ b/test/integrators/initialization.jl
@@ -26,13 +26,13 @@ using Test
     prob_ddae = DDEProblem(
         DDEFunction{true}(sir_ddae!;
             mass_matrix = Diagonal([1.0, 1.0, 0.0])),
-        u0,
+        u0_good,
         sir_history,
         tspan,
         p;
         constant_lags = (p.τ,))
     alg = MethodOfSteps(Rosenbrock23())
     @test_nowarn init(prob_ddae, alg)
-    prob.u0[1] = 2.0
+    prob_ddae.u0[1] = 2.0
     @test_throws SciMLBase.CheckInitFailureError init(prob_ddae, alg)
 end

--- a/test/integrators/initialization.jl
+++ b/test/integrators/initialization.jl
@@ -1,5 +1,6 @@
 using DelayDiffEq
 using SciMLBase
+using SciMLBase
 using LinearAlgebra
 using Test
 

--- a/test/integrators/initialization.jl
+++ b/test/integrators/initialization.jl
@@ -1,5 +1,4 @@
 using DelayDiffEq
-using SciMLBase
 using LinearAlgebra
 using Test
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context
Oops, I could have sworn I made this PR last week
The cache tests that are @test_nowarn were failing because of the new ADTypes integration for OrdinaryDiffEq. Setting the chunk_size to 1 should be unecessary, since that will happen automatically anyway.
