### PR TITLE
Fix the Jac and Grad Resizing 

### DIFF
--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -203,6 +203,7 @@ function DiffEqBase.resize_non_user_cache!(integrator::DDEIntegrator,
         cache::RosenbrockMutableCache, i)
     cache.J = similar(cache.J, i, i)
     cache.W = similar(cache.W, i, i)
+    
     if cache.jac_config isa Tuple
         OrdinaryDiffEqDifferentiation.resize_jac_config!(cache, integrator)
         OrdinaryDiffEqDifferentiation.resize_grad_config!(cache, integrator)

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -203,8 +203,10 @@ function DiffEqBase.resize_non_user_cache!(integrator::DDEIntegrator,
         cache::RosenbrockMutableCache, i)
     cache.J = similar(cache.J, i, i)
     cache.W = similar(cache.W, i, i)
-    OrdinaryDiffEqDifferentiation.resize_jac_config!(cache.jac_config, i)
-    OrdinaryDiffEqDifferentiation.resize_grad_config!(cache.grad_config, i)
+
+    
+    OrdinaryDiffEqDifferentiation.resize_jac_config!(cache.uf, cache.du1, cache.jac_config, OrdinaryDiffEqCore.alg_autodiff(integrator.alg), integrator.u)
+    OrdinaryDiffEqDifferentiation.resize_grad_config!(cache.uf, cache.du1, cache.grad_config, OrdinaryDiffEqCore.alg_autodiff(integrator.alg), integrator.u)
     nothing
 end
 

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -203,8 +203,14 @@ function DiffEqBase.resize_non_user_cache!(integrator::DDEIntegrator,
         cache::RosenbrockMutableCache, i)
     cache.J = similar(cache.J, i, i)
     cache.W = similar(cache.W, i, i)
-    OrdinaryDiffEqDifferentiation.resize_jac_config!(cache, integrator)
-    OrdinaryDiffEqDifferentiation.resize_grad_config!(cache, integrator)
+    if cache.jac_config isa Tuple
+        OrdinaryDiffEqDifferentiation.resize_jac_config!(cache, integrator)
+        OrdinaryDiffEqDifferentiation.resize_grad_config!(cache, integrator)
+    else
+        OrdinaryDiffEqDifferentiation.resize_jac_config!(cache.jac_config, integrator)
+        OrdinaryDiffEqDifferentiation.resize_grad_config!(cache.grad_config, integrator)
+    end
+
     nothing
 end
 

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -210,8 +210,8 @@ function DiffEqBase.resize_non_user_cache!(integrator::DDEIntegrator,
         OrdinaryDiffEqDifferentiation.resize_jac_config!(cache, integrator)
         OrdinaryDiffEqDifferentiation.resize_grad_config!(cache, integrator)
     else
-        OrdinaryDiffEqDifferentiation.resize_jac_config!(cache.jac_config, integrator)
-        OrdinaryDiffEqDifferentiation.resize_grad_config!(cache.grad_config, integrator)
+        OrdinaryDiffEqDifferentiation.resize_jac_config!(cache.jac_config, i)
+        OrdinaryDiffEqDifferentiation.resize_grad_config!(cache.grad_config, i)
     end
 
     nothing

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -203,7 +203,9 @@ function DiffEqBase.resize_non_user_cache!(integrator::DDEIntegrator,
         cache::RosenbrockMutableCache, i)
     cache.J = similar(cache.J, i, i)
     cache.W = similar(cache.W, i, i)
-    
+
+    # jac and grad configs after DI integration are Tuples, and resizing needs cache
+    # before DI integration, these just need the config and the integrator
     if cache.jac_config isa Tuple
         OrdinaryDiffEqDifferentiation.resize_jac_config!(cache, integrator)
         OrdinaryDiffEqDifferentiation.resize_grad_config!(cache, integrator)

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -203,10 +203,8 @@ function DiffEqBase.resize_non_user_cache!(integrator::DDEIntegrator,
         cache::RosenbrockMutableCache, i)
     cache.J = similar(cache.J, i, i)
     cache.W = similar(cache.W, i, i)
-
-    
-    OrdinaryDiffEqDifferentiation.resize_jac_config!(cache.uf, cache.du1, cache.jac_config, OrdinaryDiffEqCore.alg_autodiff(integrator.alg), integrator.u)
-    OrdinaryDiffEqDifferentiation.resize_grad_config!(cache.uf, cache.du1, cache.grad_config, OrdinaryDiffEqCore.alg_autodiff(integrator.alg), integrator.u)
+    OrdinaryDiffEqDifferentiation.resize_jac_config!(cache, integrator)
+    OrdinaryDiffEqDifferentiation.resize_grad_config!(cache, integrator)
     nothing
 end
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This changes to using the modified `resize_jac_config!` in OrdinaryDiffEqCore, so the caches can be resized correctly.