### PR TITLE
Add solver API documentation

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,24 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: '1'
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia --project=docs/ docs/make.jl

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,25 @@
+using Documenter, DelayDiffEq
+
+cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml", force = true)
+cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
+
+include("pages.jl")
+
+makedocs(
+    sitename = "DelayDiffEq.jl",
+    authors = "Chris Rackauckas et al.",
+    clean = true,
+    doctest = false,
+    modules = [DelayDiffEq],
+    warnonly = [:docs_block, :missing_docs, :eval_block],
+    format = Documenter.HTML(
+        analytics = "UA-90474609-3",
+        canonical = "https://delaydiffeq.sciml.ai/stable/"
+    ),
+    pages = pages
+)
+
+deploydocs(
+    repo = "github.com/SciML/DelayDiffEq.jl";
+    push_preview = true
+)

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -1,0 +1,4 @@
+pages = [
+    "DelayDiffEq.jl: DDE solvers" => "index.md",
+    "Solver API" => "solvers/api.md"
+]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,46 @@
+# DelayDiffEq.jl: Delay Differential Equation Solvers
+
+DelayDiffEq.jl is a component package of the DifferentialEquations.jl ecosystem for solving delay differential equations (DDEs). It provides the core algorithms and method of steps implementations for solving DDEs with both constant and state-dependent delays.
+
+## Features
+
+- Method of steps algorithms with automatic step size control
+- Support for both constant and state-dependent delays
+- Compatible with all ODE solvers from OrdinaryDiffEq.jl
+- Automatic discontinuity tracking for accurate solutions
+- Full compatibility with the DifferentialEquations.jl common interface
+
+## Installation
+
+To install DelayDiffEq.jl, use the Julia package manager:
+
+```julia
+using Pkg
+Pkg.add("DelayDiffEq")
+```
+
+## Quick Example
+
+```julia
+using DelayDiffEq, Plots
+
+# Define a DDE with constant delay
+function bc_model(du,u,h,p,t)
+    du[1] = 1.1/(1 + sqrt(10)*(h(p, t-20)[1])^(5/4)) - 10*u[1]/(1 + 40*u[2])
+    du[2] = 100*u[1]/(1 + 40*u[2]) - 2.43*u[2]
+end
+
+h(p, t) = ones(2)
+tspan = (0.0,100.0)
+u0 = [1.05767027/3, 1.030713491/3]
+
+prob = DDEProblem(bc_model,u0,h,tspan; constant_lags=[20.0])
+sol = solve(prob,MethodOfSteps(Tsit5()))
+plot(sol)
+```
+
+## Getting Started
+
+For more examples and tutorials, see the [DifferentialEquations.jl DDE tutorial](https://docs.sciml.ai/DiffEqDocs/stable/tutorials/dde_example/).
+
+For the list of available algorithms and their properties, see the [Solver API](@ref) documentation.

--- a/docs/src/solvers/api.md
+++ b/docs/src/solvers/api.md
@@ -1,0 +1,134 @@
+```@meta
+CollapsedDocStrings = true
+```
+
+# Solver API
+
+DelayDiffEq.jl provides delay differential equation solvers through the method of steps approach. The core algorithm wraps ODE solvers from OrdinaryDiffEq.jl to handle the delays.
+
+## Method of Steps Algorithm
+
+The primary algorithm for solving delay differential equations in DelayDiffEq.jl is `MethodOfSteps`, which implements the method of steps approach for solving DDEs.
+
+```@docs
+MethodOfSteps
+```
+
+### Algorithm Properties
+
+- **Adaptive**: Inherits adaptivity from the underlying ODE solver
+- **Order**: Depends on the chosen ODE algorithm
+- **Dense Output**: Available when the underlying ODE solver supports it
+- **State-Dependent Delays**: Supported through fixed-point iteration
+
+## Usage
+
+### Basic Usage
+
+```julia
+using DelayDiffEq, OrdinaryDiffEq
+
+# Use with any ODE solver from OrdinaryDiffEq.jl
+alg = MethodOfSteps(Tsit5())
+sol = solve(prob, alg)
+```
+
+### Constrained vs Unconstrained
+
+By default, `MethodOfSteps` is unconstrained, meaning it can take steps larger than the minimal delay using fixed-point iteration:
+
+```julia
+# Unconstrained (default) - can take larger steps
+alg = MethodOfSteps(Tsit5())
+
+# Constrained - steps limited to minimal delay
+alg = MethodOfSteps(Tsit5(); constrained = true)
+```
+
+### Custom Fixed-Point Solver
+
+For unconstrained problems, you can specify the fixed-point iteration method:
+
+```julia
+# Use custom fixed-point solver
+alg = MethodOfSteps(Tsit5(); fpsolve = NLFunctional(; max_iter = 100))
+```
+
+## Recommended Algorithms
+
+The choice of underlying ODE algorithm depends on your problem characteristics:
+
+### Non-Stiff Problems
+
+For non-stiff delay differential equations:
+
+- **`MethodOfSteps(Tsit5())`**: Good general purpose solver (5th order)
+- **`MethodOfSteps(BS3())`**: For lower accuracy requirements (3rd order)
+- **`MethodOfSteps(Vern6())`**: For high accuracy requirements (6th order)
+- **`MethodOfSteps(Vern9())`**: For very high accuracy requirements (9th order)
+
+### Stiff Problems
+
+For stiff delay differential equations:
+
+- **`MethodOfSteps(Rosenbrock23())`**: Good for mildly stiff problems
+- **`MethodOfSteps(Rodas4())`**: General purpose stiff solver
+- **`MethodOfSteps(Rodas5())`**: High accuracy stiff solver
+- **`MethodOfSteps(KenCarp4())`**: Good stability properties
+
+### Low Storage Requirements
+
+For problems with memory constraints:
+
+- **`MethodOfSteps(SSPRK104())`**: Strong stability preserving, low storage
+- **`MethodOfSteps(OwrenZen3())`**: 3rd order low storage
+- **`MethodOfSteps(OwrenZen5())`**: 5th order low storage
+
+## Algorithm Selection Guide
+
+### Step 1: Determine Stiffness
+
+First, determine if your DDE is stiff. Signs of stiffness include:
+- Explicit methods require very small time steps
+- The solution has multiple time scales
+- There are rapid transients followed by slow dynamics
+
+### Step 2: Choose Tolerance
+
+- **High tolerance (>1e-2)**: Use lower order methods
+- **Medium tolerance (1e-8 to 1e-2)**: Use standard 4-5 order methods  
+- **Low tolerance (<1e-8)**: Use high order methods
+
+### Step 3: Consider Problem Structure
+
+- **Discontinuous forcing**: Use low order methods or constrained stepping
+- **State-dependent delays**: May benefit from constrained stepping
+- **Conservation properties needed**: Consider symplectic integrators
+
+### Example Selection
+
+```julia
+# Non-stiff problem with medium accuracy
+alg = MethodOfSteps(Tsit5())
+
+# Stiff problem with medium accuracy
+alg = MethodOfSteps(Rodas4())
+
+# High accuracy non-stiff problem
+alg = MethodOfSteps(Vern9())
+
+# Problem with frequent discontinuities
+alg = MethodOfSteps(BS3(); constrained = true)
+```
+
+## Performance Tips
+
+1. **Use constrained stepping** when delays are much smaller than the timescale of the solution
+2. **Choose higher order methods** for smooth problems with stringent accuracy requirements
+3. **Use lower order methods** when the solution has many discontinuities
+4. **Monitor the number of fixed-point iterations** for unconstrained problems with state-dependent delays
+
+## See Also
+
+- [OrdinaryDiffEq.jl Solver Documentation](https://docs.sciml.ai/OrdinaryDiffEq/stable/) for details on the underlying ODE solvers
+- [DifferentialEquations.jl DDE Tutorial](https://docs.sciml.ai/DiffEqDocs/stable/tutorials/dde_example/) for comprehensive examples


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the DelayDiffEq.jl solver API, following the same structure and style as OrdinaryDiffEq.jl to maintain consistency across the SciML ecosystem.

## Changes

- Added `docs/` directory with Documenter.jl setup
- Created solver API reference page explaining the `MethodOfSteps` algorithm
- Included algorithm selection guide for different problem types (stiff/non-stiff)
- Added performance tips and usage examples
- Set up GitHub Actions workflow for automatic documentation building and deployment

## Documentation Structure

The documentation follows the pattern established by OrdinaryDiffEq.jl:
- Clear explanation of the main algorithm (`MethodOfSteps`)
- Algorithm properties and options
- Recommended solvers for different scenarios
- Performance tips and best practices

## Test Plan

- [ ] Documentation builds successfully with `julia --project=docs/ docs/make.jl`
- [ ] All code examples in the documentation run without errors
- [ ] Links to external resources are valid
- [ ] Documentation deploys correctly to GitHub Pages

🤖 Generated with [Claude Code](https://claude.ai/code)