### PR TITLE
Fix citation formatting in algorithms.jl

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -22,12 +22,12 @@ Citations:
 
 General Approach
 
-ZivariPiran, Hossein, and Wayne H. Enright. "An efficient unified approach for the numerical 
+Zivari-Piran, Hossein, and Wayne H. Enright. "An efficient unified approach for the numerical 
 solution of delay differential equations." Numerical Algorithms 53.2-3 (2010): 397-417.
 
 State-Dependent Delays
 
-S. P. Corwin, D. Sarafyan and S. Thompson in "DKLAG6: a code based on continuously imbedded
+S. P. Corwin, D. Sarafyan and S. Thompson in "DKLAG6: a code based on continuously embedded
 sixth-order Runge-Kutta methods for the solution of state-dependent functional differential
 equations", Applied Numerical Mathematics, 1997.
 """


### PR DESCRIPTION
## Summary

This PR fixes minor formatting issues in the citations within the `MethodOfSteps` docstring in `algorithms.jl`:

1. **Author name formatting**: Changed "ZivariPiran" to "Zivari-Piran" (added hyphen for proper formatting)
2. **Spelling modernization**: Changed "imbedded" to "embedded" (using the more common modern spelling)

## Changes

- Fixed author name in citation: `ZivariPiran, Hossein` → `Zivari-Piran, Hossein`
- Updated spelling: `continuously imbedded` → `continuously embedded`

## Test Plan

These are documentation-only changes that don't affect functionality. The package tests pass without modification.

🤖 Generated with [Claude Code](https://claude.ai/code)