### PR TITLE
Export utility functions has_constant_lags and has_dependent_lags

### DIFF
--- a/src/DelayDiffEq.jl
+++ b/src/DelayDiffEq.jl
@@ -43,7 +43,7 @@ import DiffEqBase
 
 import SciMLBase
 
-export Discontinuity, MethodOfSteps
+export Discontinuity, MethodOfSteps, has_constant_lags, has_dependent_lags
 
 include("discontinuity_type.jl")
 include("functionwrapper.jl")


### PR DESCRIPTION
## Summary

This PR exports two useful utility functions that were previously internal:
- `has_constant_lags(prob/integrator)`: Returns true if the DDE problem contains constant delays
- `has_dependent_lags(prob/integrator)`: Returns true if the DDE problem contains dependent delays

## Motivation

These functions are already well-documented and used internally throughout the codebase. Making them available to users allows them to easily inspect their DDEProblem objects to understand what types of delays they contain, which can be helpful for:

- Debugging delay configurations
- Understanding problem structure
- Making informed algorithm choices
- Educational purposes

## Implementation

The change is minimal - just adding the two function names to the export list in `src/DelayDiffEq.jl`. The functions themselves are already defined in `src/utils.jl` with comprehensive docstrings.

## Testing

Both functions work correctly with DDEProblem objects:
- `has_constant_lags` returns `true` for problems with `constant_lags`, `false` otherwise
- `has_dependent_lags` returns `true` for problems with `dependent_lags`, `false` otherwise

## Breaking Changes

This is a non-breaking change that only adds new exports. No existing functionality is modified.

🤖 Generated with [Claude Code](https://claude.ai/code)