### PR TITLE
Fix UndefRefError with default solver (fixes #329)

### DIFF
--- a/src/DelayDiffEq.jl
+++ b/src/DelayDiffEq.jl
@@ -73,11 +73,15 @@ include("solve.jl")
 include("utils.jl")
 
 # Default solver for DDEProblems
+# Note: Using Tsit5() instead of DefaultODEAlgorithm() as a workaround
+# for incompatibility between DefaultCache and OrdinaryDiffEqCore's interpolation.
+# TODO: Revert to DefaultODEAlgorithm() when OrdinaryDiffEqCore adds support
+# for DefaultCache in interpolation routines (see issue #329).
 function SciMLBase.__solve(prob::DDEProblem; kwargs...)
-    SciMLBase.solve(prob, MethodOfSteps(DefaultODEAlgorithm()); kwargs...)
+    SciMLBase.solve(prob, MethodOfSteps(Tsit5()); kwargs...)
 end
 function SciMLBase.__init(prob::DDEProblem; kwargs...)
-    DiffEqBase.init(prob, MethodOfSteps(DefaultODEAlgorithm()); kwargs...)
+    DiffEqBase.init(prob, MethodOfSteps(Tsit5()); kwargs...)
 end
 
 end # module


### PR DESCRIPTION
## Summary
- Fixes the UndefRefError that occurs when solving DDEs with the default solver introduced in v5.57
- Changes the default algorithm from `DefaultODEAlgorithm()` to `Tsit5()` as a workaround for OrdinaryDiffEqCore compatibility issue
- Resolves #329

## Background
In v5.57, support for `DefaultODEAlgorithm` was added to DelayDiffEq. However, this introduced a bug where the `DefaultCache` structure used by `DefaultODEAlgorithm` is incompatible with OrdinaryDiffEqCore's interpolation code, causing an `UndefRefError` when evaluating the history function.

The error occurs because:
1. `DefaultODEAlgorithm` creates a composite algorithm with `DefaultCache`
2. `DefaultCache` stores individual cache fields (cache1, cache2, etc.) rather than a caches array
3. OrdinaryDiffEqCore's `ode_interpolation` function doesn't know how to handle `DefaultCache` properly
4. When the history function tries to interpolate at time `t-1`, it triggers the UndefRefError

## Solution
This PR changes the default solver from `DefaultODEAlgorithm()` to `Tsit5()`. This is a temporary workaround until OrdinaryDiffEqCore adds proper support for `DefaultCache` in its interpolation routines.

## Test Results
- ✅ The minimal example from issue #329 now runs successfully
- ✅ Tests pass with both default solver and explicit `Tsit5()`
- ✅ Other algorithms (RK4, etc.) continue to work correctly

## Future Work
A proper fix would require changes to OrdinaryDiffEqCore to handle `DefaultCache` in the `ode_interpolation` function. This PR provides an immediate fix for users experiencing the issue.

🤖 Generated with [Claude Code](https://claude.ai/code)